### PR TITLE
Improve subtitle metadata availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ pkg
 script/*
 tmp/*
 Gemfile.lock
+*.gem

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,21 @@
 == Master
 
-Current with 1.1.0
+Current with 1.2.0
+
+== 1.2.0
+
+Changes:
+* Added `subtitle_tags` and `subtitle_codec_tag` movie attributes
+
+Improvements:
+* Default subtitle stream now determined by disposition metadata. If no default is present, uses first stream.
+* Improved subtitle overview including both sets of codec names and codec tags
 
 == 1.1.0
 
 Improvements:
 * Added support for reading subtitle metadata
-* Running on ruby patch 3.1.1
+* Running on ruby patch 3.3.1
 
 == 1.0.0-r3.3 2024-04-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.3.1-alpine as base
 
-RUN apk add build-base ffmpeg
+RUN apk update && apk add build-base ffmpeg
 
 WORKDIR /ruby-ffmpeg
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ movie.audio_channels # 2
 # Multiple audio streams
 movie.audio_streams[0] # "aac, 44100 Hz, stereo, s16, 75 kb/s" (raw audio stream info)
 
-movie.subtitle_stream # "tx3g (eng)"
-movie.subtitle_codec # "tx3g"
+movie.subtitle_stream # "mov_text / MOV text (tx3g / 0x67337874) (eng)"
+movie.subtitle_codec # "mov_text"
+movie.subtitle_codec_tag # "tx3g"
 movie.subtitle_language # "eng"
+movie.subtitle_tags # {:creation_time=>"2017-06-07T05:51:07.000000Z", :language=>"eng" ...
 
 # Multiple subtitle streams
 movie.subtitle_streams[0][:overview] # "tx3g (eng)"

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -8,7 +8,7 @@ module FFMPEG
     attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
-    attr_reader :subtitle_streams, :subtitle_stream, :subtitle_codec, :subtitle_language
+    attr_reader :subtitle_streams, :subtitle_stream, :subtitle_codec, :subtitle_language, :subtitle_codec_tag, :subtitle_tags
     attr_reader :container
     attr_reader :metadata, :format_tags
 
@@ -131,15 +131,22 @@ module FFMPEG
           {
             :index => stream[:index],
             :language => stream[:tags][:language],
-            :codec_name => stream[:codec_tag_string],
-            :overview => "#{stream[:codec_tag_string]} (#{stream[:tags][:language]})"
+            :default => stream[:disposition][:default] == 1,
+            :codec_name => stream[:codec_name],
+            :codec_tag => stream[:codec_tag_string],
+            :tags => stream[:tags],
+            :overview => "#{stream[:codec_name]} / #{stream[:codec_long_name]} "\
+                         "(#{stream[:codec_tag_string]} / #{stream[:codec_tag]}) "\
+                         "(#{stream[:tags][:language]})"
           }
         end
 
-        subtitle_stream = @subtitle_streams.first
+        subtitle_stream = @subtitle_streams.select {|stream| stream[:default] }.first || @subtitle_streams.first
         unless subtitle_stream.nil?
           @subtitle_language = subtitle_stream[:language]
           @subtitle_codec = subtitle_stream[:codec_name]
+          @subtitle_codec_tag = subtitle_stream[:codec_tag]
+          @subtitle_tags = subtitle_stream[:tags]
           @subtitle_stream = subtitle_stream[:overview]
         end
 

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,3 +1,3 @@
 module FFMPEG
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -529,9 +529,19 @@ module FFMPEG
         expect(movie.subtitle_codec).to eq(subtitle_codec)
       end
 
+      it "should assign subtitle_codec_tag to the format of the first stream" do
+        subtitle_codec_tag = movie.subtitle_streams[0][:codec_tag]
+        expect(movie.subtitle_codec_tag).to eq(subtitle_codec_tag)
+      end
+
       it "should assign subtitle_language to the language of the first stream" do
         subtitle_language = movie.subtitle_streams[0][:language]
         expect(movie.subtitle_language).to eq(subtitle_language)
+      end
+
+      it "should assign subtitle_tags to the tags of the first stream" do
+        subtitle_tags = movie.subtitle_streams[0][:tags]
+        expect(movie.subtitle_tags).to eq(subtitle_tags)
       end
 
       it "should assign subtitle_stream to the properties of the first stream" do


### PR DESCRIPTION
Improve available metadata.

```ruby
movie.subtitle_stream # "mov_text / MOV text (tx3g / 0x67337874) (eng)"
movie.subtitle_codec # "mov_text"
movie.subtitle_codec_tag # "tx3g"
movie.subtitle_language # "eng"
movie.subtitle_tags # {:creation_time=>"2017-06-07T05:51:07.000000Z", :language=>"eng" ...
```

Decide default subtitle stream from disposition metadata.
```ruby
subtitle_stream = @subtitle_streams.select {|stream| stream[:default] }.first || @subtitle_streams.first
```
If there are no default streams, use the first stream.